### PR TITLE
Set default message renderer to default renderer

### DIFF
--- a/app/views/projects/_redmine_kato.html.erb
+++ b/app/views/projects/_redmine_kato.html.erb
@@ -1,4 +1,5 @@
 <p>
   <%= form.text_field :kato_url, :size => 60 %>
-  <a href="https://kato.im" target="_blank">Kato</a> webhook URL from your room integrations panel. Leave empty to use <%= link_to 'global settings', plugin_settings_path(:redmine_kato) %>.
+  <a href="https://kato.im" target="_blank">Kato</a> webhook URL from your room integrations panel. Leave empty to use <%= link_to 'global settings', plugin_settings_path(:redmine_kato) %>.<br />
+  <%= form.check_box :kato_uses_markdown, {}, 1, 0 %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,5 @@ en:
   kato_settings_header: Kato Plugin Configuration
   kato_settings_label_url: Kato webhook URL
   kato_settings_label_projects: Projects
+  field_kato_uses_markdown: Use Markdown format in Kato messages
   field_kato_url: Kato webhook URL

--- a/db/migrate/002_add_per_project_format_settings_to_project.rb
+++ b/db/migrate/002_add_per_project_format_settings_to_project.rb
@@ -1,0 +1,5 @@
+class AddPerProjectFormatSettingsToProject < ActiveRecord::Migration
+  def change
+    add_column :projects, :kato_uses_markdown, :boolean, :default => false, :null => false
+  end
+end

--- a/lib/project_patch.rb
+++ b/lib/project_patch.rb
@@ -4,6 +4,7 @@ module RedmineKato
       def self.included(base)
         base.class_eval do
           safe_attributes 'kato_url'
+          safe_attributes 'kato_uses_markdown'
         end
       end
     end


### PR DESCRIPTION
This is the fix to the feature request proposed yesterday (from my company's support window).

I think it is better to default the renderer of Redmine messages to plain text because Redmine messages do not necessarily use Markdown. In versions prior to 2.5 Redmine does not support Markdown and uses Textile instead (this is my company's case). Also, posts often begin with an issue number starting with a `#`, which leads to rendering large characters in the chat window.
It may be better if users can select which behavior to use from Redmine's plugin setting window; I will try it later.
